### PR TITLE
Pass the read and open timeout options

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "hubspot-ruby"
-  s.version = "0.6.3"
+  s.version = "0.6.5"
   s.require_paths = ["lib"]
   s.authors = ["Andrew DiMichele", "Chris Bisnett"]
   s.description = "hubspot-ruby is a wrapper for the HubSpot REST API"

--- a/lib/hubspot/oauth.rb
+++ b/lib/hubspot/oauth.rb
@@ -38,12 +38,22 @@ module Hubspot
           redirect_uri: Hubspot::Config.redirect_uri,
         }.merge(params)
 
-        response = post(url, body: body, headers: DEFAULT_OAUTH_HEADERS)
+        response = post(url, body: body, headers: DEFAULT_OAUTH_HEADERS, read_timeout: read_timeout(options), open_timeout: open_timeout(options))
         log_request_and_response url, response, body
 
         raise(Hubspot::RequestError.new(response)) unless response.success?
 
         no_parse ? response : response.parsed_response
+      end
+
+      private
+
+      def read_timeout(opts = {})
+        opts.delete(:read_timeout) || Hubspot::Config.read_timeout
+      end
+
+      def open_timeout(opts = {})
+        opts.delete(:open_timeout) || Hubspot::Config.open_timeout
       end
     end
   end


### PR DESCRIPTION
Set the `read_timeout` and `open_timeout` options when performing OAuth requests.